### PR TITLE
QoL improvements for WatchWolfResults

### DIFF
--- a/src/watchWolf/WatchWolfResults.tsx
+++ b/src/watchWolf/WatchWolfResults.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { useAtom, useAtomValue } from 'jotai';
 import { cardsAtom } from '../hellfall/cardsAtom';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { TeamWolf as GetCardVotes } from './TeamWolf';
 import {
   SidePanelOpenDirection,
@@ -16,6 +16,8 @@ import { useKeyPress } from '../hooks';
 
 //TODO: make results use Id natively on the backend
 
+interface Standing { Id: string; Wins: number; Matches: number; Winrate?: string }
+
 export const Watchwolfresults = () => {
   const escape = useKeyPress('Escape');
   const cards = useAtomValue(cardsAtom).filter(e => e.set != 'C');
@@ -26,10 +28,44 @@ export const Watchwolfresults = () => {
       setActiveCardFromAtom('');
     }
   }, [escape]);
-  const [standings, setStandings] = useState<{ Id: string; Wins: number; Matches: number }[]>();
+  const [standings, setStandings] = useState<Standing[]>();
   useEffect(() => {
     GetCardVotes().then(setStandings);
   }, []);
+
+  const wrGroupedStandings = useMemo(() => {
+    if (!standings) return [];
+    // first we create an object where the keys are winrates and the values are arrays of standings.
+    const buckets = standings
+      .reduce<Record<string, Standing[]>>((accumulator, standing) => {
+        const winrate = ((standing.Wins / standing.Matches) * 100).toFixed(0)
+        if (!(winrate in accumulator)) {
+          // this winrate does not exist in the accumulator object yet,
+          // lets create an empty array under its key. 
+          accumulator[winrate] = []
+        }
+        accumulator[winrate].push({ ...standing, Winrate: winrate })
+        return accumulator
+      }, {})
+    // then we sort all value arrays so we dont have to do it at render
+    for (const wrKey in buckets) {
+      const wr = Number(wrKey)
+      buckets[wrKey].sort((a, b) => {
+        // if wr >= 50, we want to sort by wins descending
+        if (wr >= 50) {
+          return b.Wins - a.Wins
+        }
+        // if wr < 50, we want to sort by matches - wins (losses) ascending
+        return (a.Matches - a.Wins) - (b.Matches - b.Wins)
+      })
+    }
+    // then we sort the keys so we can iterate over them in order
+    const sortedKeys = Object.keys(buckets).sort((a, b) => Number(b) - Number(a))
+    // and last we flatten the buckets into a single array
+    const flattened = sortedKeys.flatMap(key => buckets[key])
+    return flattened
+  }, [standings])
+
   return (
     <PageContainer>
       <StyledSidePanel
@@ -61,25 +97,30 @@ export const Watchwolfresults = () => {
       </StyleComponent>
       <StyleComponent>
         <ResultsReceptaclePlaceThing>
-          {standings
-            ?.sort((a, b) => {
-              return b.Wins / b.Matches - a.Wins / a.Matches;
-            })
-            .slice(0, cards.length)
+          {/* Header row, but we just re-use the ResultRow component */}
+          <ResultRow style={{ marginBottom: 6 }}>
+            <div><strong>Card Name</strong> [Creator]</div>
+            <span>Winrate</span>
+            <span>W/L</span>
+          </ResultRow>
+
+          {wrGroupedStandings
+            ?.slice(0, cards.length)
             .map(entry => {
-              const name = cards.find(e => entry.Id === e.id)?.name;
+              const card = cards.find(e => entry.Id === e.id);
+              if (!card) return null;
+
               return (
-                <div key={entry.Id}>
-                  <span
-                    key={entry.Id}
-                    onClick={() => {
-                      setActiveCardFromAtom(entry.Id);
-                    }}
-                  >
-                    {name} - {((entry.Wins / entry.Matches) * 100).toFixed(2)}% Win Rate (
-                    {entry.Wins}/{entry.Matches})
-                  </span>
-                </div>
+                <ResultRow
+                  key={entry.Id}
+                  onClick={() => {
+                    setActiveCardFromAtom(entry.Id);
+                  }}
+                >
+                  <div><strong>{card.name}</strong> [{card.creator}]</div>
+                  <span>{entry.Winrate}%</span>
+                  <span>{entry.Wins}/{entry.Matches}</span>
+                </ResultRow>
               );
             })}
         </ResultsReceptaclePlaceThing>
@@ -102,12 +143,35 @@ const Subtitle = styled('h3')({ textAlign: 'center', marginBottom: '30px' });
 const ResultsReceptaclePlaceThing = styled('div')({
   width: '100%',
   maxWidth: '600px',
-  padding: '20px',
-  backgroundColor: 'grey',
+  padding: '8px 0px',
+  backgroundColor: '#f0f0f0',
   border: '1px solid #ccc',
   boxShadow: '0 2px 8px rgb(164, 45, 168)',
   textAlign: 'center',
 });
+const ResultRow = styled('div')`
+  display: flex;
+  gap: 8px;
+  cursor: pointer;
+  padding: 0px 16px;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:nth-child(odd) {
+    background-color: #f0f0f0;
+  }
+
+  &:nth-child(even) {
+    background-color: #e0e0e0;
+  }
+
+  & > div {
+    flex: 1;
+    text-align: left;
+  }
+`
 
 const StyleComponent = styled('div')({ color: 'purple', display: 'flex' });
 


### PR DESCRIPTION
Some QoL improvements to the WatchWolfResults component:
* Sort each "winrate bucket" based on wins/losses.
* Creator name next to cards in list.
* General list styling lifts.
<img width="1425" height="926" alt="image" src="https://github.com/user-attachments/assets/9790b924-ea9c-4481-b7f0-fe070616c805" />