### PR TITLE
Firestore catalog refactor (merge stash into idfixes)

### DIFF
--- a/packages/backend/src/hc-transformations.ts
+++ b/packages/backend/src/hc-transformations.ts
@@ -31,8 +31,8 @@ import {
   getFilteredRootProps,
   deletePropFromRoot,
   anyValueType,
-  mergeFromSheet,
 } from '@hellfall/shared/utils';
+import { mergeFromSheet } from '@hellfall/shared/utils/cardModification/changeHandling';
 import namesRawData from '@hellfall/shared/data/oracle-names.json';
 import { addToJSONToCards } from '@hellfall/shared/utils';
 import { fetchHCJFronts } from './fetchHCJFronts.ts';

--- a/packages/frontend/src/hellfall/card/CardEditPanel.tsx
+++ b/packages/frontend/src/hellfall/card/CardEditPanel.tsx
@@ -4,14 +4,8 @@ import { Card } from '@workday/canvas-kit-react';
 import type { HCCard } from '@hellfall/shared/types';
 import { useAuth } from '../../auth';
 import { getAuthApiUrl } from '../../auth/getAuthApiUrl';
-import {
-  anyChange,
-  faceChange,
-  faceMappedType,
-  faceValueType,
-  getFaceEntries,
-  toFaces,
-} from '@hellfall/shared/utils';
+import type { anyChange, faceChange, faceMappedType, faceValueType } from '@hellfall/shared/utils';
+import { getFaceEntries, toFaces } from '@hellfall/shared/utils';
 
 export type EditableFields = {
   name: string;

--- a/packages/frontend/src/review/types.ts
+++ b/packages/frontend/src/review/types.ts
@@ -1,4 +1,4 @@
-import { anyChange } from '@hellfall/shared/utils';
+import type { anyChange } from '@hellfall/shared/utils';
 
 export interface ChangesetUser {
   userId: string;

--- a/packages/scripts/src/export-hellscube-db.ts
+++ b/packages/scripts/src/export-hellscube-db.ts
@@ -3,7 +3,7 @@
  *
  * Usage: see packages/scripts/README.md
  */
-import { exportHellscubeCards } from '@hellfall/shared/utils';
+import { exportHellscubeCards } from './lib/exportCards.js';
 import { config } from 'dotenv';
 import { writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';

--- a/packages/scripts/src/lib/exportCards.ts
+++ b/packages/scripts/src/lib/exportCards.ts
@@ -1,0 +1,6 @@
+export {
+  exportHellscubeCards,
+  type HellscubeExportCard,
+  type HellscubeExportOptions,
+  type HellscubeExportPayload,
+} from '@hellfall/server/lib/exportHellscubeCards';

--- a/packages/scripts/src/migrate-hellscube-db.ts
+++ b/packages/scripts/src/migrate-hellscube-db.ts
@@ -26,14 +26,8 @@ import { Firestore, type CollectionReference } from '@google-cloud/firestore';
 //   type CardTagState,
 // } from '@hellfall/shared/cardTags/cardTagMerge.ts';
 import { HCCard, tagState } from '@hellfall/shared/types';
-import {
-  CardMap,
-  cardToFirestore,
-  firestoreCard,
-  mergeTagStates,
-  tagRecordsEqual,
-  updateTags,
-} from '@hellfall/shared/utils';
+import { CardMap, mergeTagStates, tagRecordsEqual, updateTags } from '@hellfall/shared/utils';
+import { cardToFirestore, firestoreCard } from '@hellfall/shared/utils/firestore';
 import { JsonDataWrapper } from '@hellfall/shared/data';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/packages/server/src/api/cardTags.ts
+++ b/packages/server/src/api/cardTags.ts
@@ -5,13 +5,8 @@ import type { HandlerRequest, HandlerResponse } from './lib/types.js';
 import { requireTagAuth } from './lib/requireTagAuth.js';
 import { listCardChangesets, recordTagChangeset } from '../lib/cardAudit.js';
 import { HCCard, tagState } from '@hellfall/shared/types';
-import {
-  addTagContributor,
-  cardToFirestore,
-  deleteTagContributor,
-  firestoreCard,
-  firestoreToCard,
-} from '@hellfall/shared/utils';
+import { addTagContributor, deleteTagContributor } from '@hellfall/shared/utils';
+import { cardToFirestore, firestoreCard, firestoreToCard } from '@hellfall/shared/utils/firestore';
 // import {
 //   applyAddTag,
 //   applyRemoveTag,

--- a/packages/server/src/api/changesets.ts
+++ b/packages/server/src/api/changesets.ts
@@ -6,14 +6,13 @@ import { requireTagAuth } from './lib/requireTagAuth.js';
 import { requireAdminAuth } from './lib/requireAdminAuth.js';
 import { requireReviewerAuth } from './lib/requireReviewerAuth.js';
 import { recardCardChangeset } from '../lib/cardAudit.js';
+import { isValidV4UUID } from '@hellfall/shared/utils';
 import {
   anyChange,
   applyFromCollection,
-  cardToFirestore,
   changeIsValid,
-  firestoreToCard,
-  isValidV4UUID,
-} from '@hellfall/shared/utils';
+} from '@hellfall/shared/utils/cardModification/changeHandling';
+import { cardToFirestore, firestoreToCard } from '@hellfall/shared/utils/firestore';
 // import {
 //   resolveTagState,
 //   tagFieldsForWrite,

--- a/packages/server/src/api/exportHellscube.ts
+++ b/packages/server/src/api/exportHellscube.ts
@@ -1,4 +1,4 @@
-import { exportHellscubeCards } from '@hellfall/shared/utils';
+import { exportHellscubeCards } from '../lib/exportHellscubeCards.ts';
 import { withCors } from './lib/cors.ts';
 import { env } from './lib/env.ts';
 import { requireAdminAuth } from './lib/requireAdminAuth.ts';

--- a/packages/server/src/lib/catalogCache.ts
+++ b/packages/server/src/lib/catalogCache.ts
@@ -1,7 +1,6 @@
 import type { HCCard } from '@hellfall/shared/types';
-// import { loadHellscubeCatalogCards } from '@hellfall/shared/export/loadHellscubeCatalog';
 import { env } from '../api/lib/env.ts';
-import { exportCardMap } from '@hellfall/shared/utils';
+import { loadHellscubeCatalogCards } from './loadHellscubeCatalog.ts';
 
 const DEFAULT_TTL_MS = 15 * 60 * 1000;
 
@@ -23,7 +22,7 @@ function cacheTtlMs(): number {
 
 async function buildCatalogBody(): Promise<string> {
   const t0 = Date.now();
-  const data = await exportCardMap({
+  const data = await loadHellscubeCatalogCards({
     databaseId: env.FIRESTORE_DATABASE_ID,
     collectionName: env.FIRESTORE_CARDS_COLLECTION,
   });
@@ -32,7 +31,7 @@ async function buildCatalogBody(): Promise<string> {
   const body = JSON.stringify({ data });
   const stringifyMs = Date.now() - t1;
   console.log(
-    `[cards/load] buildCatalogBody cards=${data.size()} firestore=${loadMs}ms stringify=${stringifyMs}ms total=${Date.now() - t0}ms bytes=${body.length}`
+    `[cards/load] buildCatalogBody cards=${data.length} firestore=${loadMs}ms stringify=${stringifyMs}ms total=${Date.now() - t0}ms bytes=${body.length}`
   );
   return body;
 }

--- a/packages/server/src/lib/exportHellscubeCards.ts
+++ b/packages/server/src/lib/exportHellscubeCards.ts
@@ -1,0 +1,64 @@
+import type { Timestamp } from '@google-cloud/firestore';
+import { getFirestore, resolveCardsCollectionName } from './firestoreClient.ts';
+
+export type HellscubeExportCard = Record<string, unknown> & { _docId: string };
+
+export type HellscubeExportPayload = {
+  exportedAt: string;
+  databaseId: string;
+  collection: string;
+  data: HellscubeExportCard[];
+};
+
+export type HellscubeExportOptions = {
+  databaseId?: string;
+  collectionName?: string;
+};
+
+function serializeValue(value: unknown): unknown {
+  if (value == null) return value;
+  if (typeof value === 'object' && value !== null && 'toDate' in value) {
+    const ts = value as Timestamp;
+    if (typeof ts.toDate === 'function') {
+      return ts.toDate().toISOString();
+    }
+  }
+  if (Array.isArray(value)) {
+    return value.map(serializeValue);
+  }
+  if (typeof value === 'object' && value.constructor === Object) {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      out[k] = serializeValue(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+function docToExportRow(docId: string, data: Record<string, unknown>): HellscubeExportCard {
+  const serialized = serializeValue(data) as Record<string, unknown>;
+  return { _docId: docId, ...serialized };
+}
+
+/** Export all documents from the Hellscube cards collection as stored in Firestore. */
+export async function exportHellscubeCards(
+  options: HellscubeExportOptions = {}
+): Promise<HellscubeExportPayload> {
+  const databaseId =
+    options.databaseId?.trim() || process.env.FIRESTORE_DATABASE_ID?.trim() || 'hellscube';
+  const collectionName = resolveCardsCollectionName(options.collectionName);
+
+  const snapshot = await getFirestore(databaseId).collection(collectionName).get();
+
+  const data = snapshot.docs.map(doc =>
+    docToExportRow(doc.id, doc.data() as Record<string, unknown>)
+  );
+
+  return {
+    exportedAt: new Date().toISOString(),
+    databaseId,
+    collection: collectionName,
+    data,
+  };
+}

--- a/packages/server/src/lib/firestoreClient.ts
+++ b/packages/server/src/lib/firestoreClient.ts
@@ -1,0 +1,18 @@
+import { Firestore } from '@google-cloud/firestore';
+
+const clients = new Map<string, Firestore>();
+
+/** Reuse Firestore clients (avoids connection setup per request). */
+export function getFirestore(databaseId?: string): Firestore {
+  const id = databaseId?.trim() || process.env.FIRESTORE_DATABASE_ID?.trim() || 'hellscube';
+  let db = clients.get(id);
+  if (!db) {
+    db = new Firestore({ databaseId: id });
+    clients.set(id, db);
+  }
+  return db;
+}
+
+export function resolveCardsCollectionName(collectionName?: string): string {
+  return collectionName?.trim() || process.env.FIRESTORE_CARDS_COLLECTION?.trim() || 'cards';
+}

--- a/packages/server/src/lib/loadHellscubeCatalog.ts
+++ b/packages/server/src/lib/loadHellscubeCatalog.ts
@@ -1,0 +1,33 @@
+import type { HCCard } from '@hellfall/shared/types';
+import { firestoreToCard, type firestoreCard } from '@hellfall/shared/utils/firestore';
+import type { HellscubeExportOptions } from './exportHellscubeCards.ts';
+import { getFirestore, resolveCardsCollectionName } from './firestoreClient.ts';
+
+/**
+ * Load the playable catalog from Firestore in one pass (no deep export serialize).
+ * Uses `object == 'card'` when possible to skip tag-only stub documents.
+ */
+export async function loadHellscubeCatalogCards(
+  options: HellscubeExportOptions = {}
+): Promise<HCCard.Any[]> {
+  const databaseId =
+    options.databaseId?.trim() || process.env.FIRESTORE_DATABASE_ID?.trim() || 'hellscube';
+  const collectionName = resolveCardsCollectionName(options.collectionName);
+
+  const col = getFirestore(databaseId).collection(collectionName);
+
+  let snapshot = await col.where('object', '==', 'card').get();
+  if (snapshot.empty) {
+    snapshot = await col.get();
+  }
+
+  const cards: HCCard.Any[] = [];
+  for (const doc of snapshot.docs) {
+    const data = doc.data() as firestoreCard;
+    if (data.object !== 'card' && !(typeof data.name === 'string' && data.name.length > 0)) {
+      continue;
+    }
+    cards.push(firestoreToCard(data));
+  }
+  return cards;
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -50,6 +50,10 @@
     "./utils/firestore": {
       "types": "./src/utils/firestore/index.ts",
       "import": "./src/utils/firestore/index.ts"
+    },
+    "./utils/cardModification/changeHandling": {
+      "types": "./src/utils/cardModification/changeHandling.ts",
+      "import": "./src/utils/cardModification/changeHandling.ts"
     }
   },
   "dependencies": {

--- a/packages/shared/src/data/data.node.ts
+++ b/packages/shared/src/data/data.node.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 // import { loadHellscubeCatalogCards } from '../export/loadHellscubeCatalog';
 import { HCCard, HCCardSymbol, HCSet } from '../types';
-import { exportCardMap } from '../utils';
+import { exportCardMap } from '../utils/firestore';
 // import { error } from 'console';
 
 export interface JsonDataWrapper<T> {

--- a/packages/shared/src/utils/cardHandling/cardMethods.ts
+++ b/packages/shared/src/utils/cardHandling/cardMethods.ts
@@ -20,7 +20,7 @@ import {
 } from '../textHandling';
 import { CardMap } from './cardMap';
 import { getHc5 } from './getHc5';
-import { CollectionReference } from '@google-cloud/firestore';
+import type { CollectionReference } from '@google-cloud/firestore';
 
 /**
  * Converts the card to an array of its faces.

--- a/packages/shared/src/utils/cardModification/changeHandling.ts
+++ b/packages/shared/src/utils/cardModification/changeHandling.ts
@@ -46,10 +46,28 @@ import { setDerivedProps } from './derivedProps';
 import { cleanParts, updateParts } from './partsHandling';
 import { textEquals } from '../textHandling';
 import { toMultiFaced, toSingleFaced } from './defaults';
-import { CollectionReference, DocumentReference } from '@google-cloud/firestore';
+import type { CollectionReference, DocumentReference } from '@google-cloud/firestore';
 import { cardToFirestore, firestoreCard, firestoreToCard } from '../firestore';
+import type {
+  allPartsChange,
+  anyChange,
+  cardFacesChange,
+  changeType,
+  faceChange,
+  rootChange,
+  tagChange,
+} from './changeTypes';
 
-export type changeType = 'add' | 'push' | 'delete' | 'pop';
+export type {
+  allPartsChange,
+  anyChange,
+  cardFacesChange,
+  changeLocation,
+  changeType,
+  faceChange,
+  rootChange,
+  tagChange,
+} from './changeTypes';
 // commented out = currently done automatically via tags, but could concievable be done manually in the future
 export const rootChangeableProps: Record<changeType, rootPropType[]> = {
   add: [
@@ -180,40 +198,6 @@ export const faceChangeableProps: Record<changeType, facePropType[]> = {
     // 'frame_effects',
   ],
 };
-export type changeLocation = 'root' | 'face' | 'card_faces' | 'all_parts' | 'tag';
-export type rootChange<K extends rootPropType> = {
-  location: 'root';
-  change_type: changeType;
-  prop: K;
-  value?: rootValueType<K>;
-};
-export type faceChange<K extends facePropType> = {
-  location: 'face';
-  change_type: changeType;
-  prop: K;
-  value?: faceValueType<K>;
-  index?: number;
-};
-export type cardFacesChange = {
-  location: 'card_faces';
-  index: number;
-  change_type: 'add' | 'delete';
-  face?: HCCardFace.MultiFaced;
-};
-export type allPartsChange = {
-  location: 'all_parts';
-  change_type: 'add' | 'delete';
-  id?: string;
-  part_prop?: 'name' | 'hcid';
-  related?: HCRelatedCard;
-  no_overwrite?: boolean;
-};
-export type tagChange = {
-  location: 'tag';
-  change_type: 'add' | 'delete';
-  tag: string;
-};
-
 export const colorsAreValid = (colors: HCColors): boolean => {
   const colorList: HCColors = [];
   for (const color of colors) {
@@ -233,13 +217,6 @@ export const legalitiesAreValid = (
   doubleListEquals(formatList, Object.keys(legalities)) &&
   Object.values(legalities).every(legality => Object.values(HCLegality).includes(legality)) &&
   Object.entries(legalities).some(([format, legality]) => current[format] != legality);
-
-export type anyChange =
-  | rootChange<rootPropType>
-  | faceChange<facePropType>
-  | cardFacesChange
-  | allPartsChange
-  | tagChange;
 
 export const rootChangeIsValid = <K extends rootPropType>(
   card: HCCard.Any,

--- a/packages/shared/src/utils/cardModification/changeTypes.ts
+++ b/packages/shared/src/utils/cardModification/changeTypes.ts
@@ -1,0 +1,50 @@
+import type { HCCardFace, HCRelatedCard } from '@hellfall/shared/types';
+import type { facePropType, faceValueType, rootPropType, rootValueType } from '../cardHandling';
+
+export type changeType = 'add' | 'push' | 'delete' | 'pop';
+
+export type changeLocation = 'root' | 'face' | 'card_faces' | 'all_parts' | 'tag';
+
+export type rootChange<K extends rootPropType> = {
+  location: 'root';
+  change_type: changeType;
+  prop: K;
+  value?: rootValueType<K>;
+};
+
+export type faceChange<K extends facePropType> = {
+  location: 'face';
+  change_type: changeType;
+  prop: K;
+  value?: faceValueType<K>;
+  index?: number;
+};
+
+export type cardFacesChange = {
+  location: 'card_faces';
+  index: number;
+  change_type: 'add' | 'delete';
+  face?: HCCardFace.MultiFaced;
+};
+
+export type allPartsChange = {
+  location: 'all_parts';
+  change_type: 'add' | 'delete';
+  id?: string;
+  part_prop?: 'name' | 'hcid';
+  related?: HCRelatedCard;
+  no_overwrite?: boolean;
+};
+
+export type tagChange = {
+  location: 'tag';
+  change_type: 'add' | 'delete';
+  tag: string;
+};
+
+export type anyChange =
+  | rootChange<rootPropType>
+  | faceChange<facePropType>
+  | cardFacesChange
+  | allPartsChange
+  | tagChange;

--- a/packages/shared/src/utils/cardModification/index.ts
+++ b/packages/shared/src/utils/cardModification/index.ts
@@ -2,6 +2,6 @@ export * from './modificationHandling';
 export * from './derivedProps';
 export * from './tagHandling';
 export * from './partsHandling';
-export * from './changeHandling';
+export * from './changeTypes';
 // export * from './cardTagMerge';
 export * from './defaults';

--- a/scripts/check-circular-deps.mjs
+++ b/scripts/check-circular-deps.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * Detect circular TypeScript imports across workspace packages.
+ * Uses madge with each package tsconfig for path alias resolution.
+ *
+ * Baseline counts in circular-deps.baseline.json allow existing debt while
+ * blocking new cycles. Run with --update-baseline after fixing cycles.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import madge from 'madge';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+const baselinePath = path.join(__dirname, 'circular-deps.baseline.json');
+
+const packages = [
+  'packages/shared',
+  'packages/backend',
+  'packages/frontend',
+  'packages/server',
+  'packages/scripts',
+];
+
+const updateBaseline = process.argv.includes('--update-baseline');
+const verbose = process.argv.includes('--verbose');
+
+/** @type {Record<string, number>} */
+const baseline = JSON.parse(readFileSync(baselinePath, 'utf8'));
+
+/** @type {Record<string, number>} */
+const observed = {};
+/** @type {string[]} */
+const errors = [];
+
+for (const pkg of packages) {
+  const srcDir = path.join(root, pkg, 'src');
+  const tsConfig = path.join(root, pkg, 'tsconfig.json');
+
+  const result = await madge(srcDir, {
+    fileExtensions: ['ts', 'tsx'],
+    tsConfig,
+  });
+
+  const cycles = result.circular();
+  observed[pkg] = cycles.length;
+
+  if (verbose && cycles.length > 0) {
+    console.log(`\n${pkg} (${cycles.length} chain(s)):`);
+    cycles.forEach((cycle, index) => {
+      console.log(`  ${index + 1}) ${cycle.join(' → ')}`);
+    });
+  } else if (cycles.length === 0) {
+    console.log(`${pkg}: no circular dependencies`);
+  } else {
+    console.log(`${pkg}: ${cycles.length} circular dependency chain(s)`);
+  }
+}
+
+if (updateBaseline) {
+  const nextBaseline = { ...baseline, ...observed };
+  writeFileSync(baselinePath, `${JSON.stringify(nextBaseline, null, 2)}\n`);
+  console.log(`\nUpdated ${path.relative(root, baselinePath)}`);
+  process.exit(0);
+}
+
+for (const pkg of packages) {
+  const allowed = baseline[pkg];
+  if (allowed === undefined) {
+    errors.push(`${pkg}: missing baseline entry in circular-deps.baseline.json`);
+    continue;
+  }
+
+  const count = observed[pkg];
+  if (count > allowed) {
+    errors.push(
+      `${pkg}: ${count} circular chain(s) found (baseline allows ${allowed}). New cycles were introduced.`,
+    );
+  } else if (count < allowed) {
+    errors.push(
+      `${pkg}: ${count} circular chain(s) found (baseline allows ${allowed}). Cycles were fixed — run \`yarn check:circular-deps --update-baseline\`.`,
+    );
+  }
+}
+
+if (errors.length > 0) {
+  console.error('\nCircular dependency check failed:\n');
+  for (const error of errors) {
+    console.error(`  • ${error}`);
+  }
+  console.error('\nRe-run with --verbose to print full cycle paths.');
+  process.exit(1);
+}
+
+console.log('\nCircular dependency check passed (no new cycles).');
+process.exit(0);

--- a/scripts/circular-deps.baseline.json
+++ b/scripts/circular-deps.baseline.json
@@ -1,0 +1,8 @@
+{
+  "$comment": "Max allowed circular dependency chains per package. Lower when cycles are fixed.",
+  "packages/shared": 35,
+  "packages/backend": 0,
+  "packages/frontend": 0,
+  "packages/server": 0,
+  "packages/scripts": 0
+}


### PR DESCRIPTION
## Summary
- Resolves stash/upstream conflicts from merging the Firestore catalog refactor into `idfixes`
- Moves server-side catalog loading and card export into dedicated modules (`loadHellscubeCatalog`, `exportHellscubeCards`, `firestoreClient`)
- Splits change types into `changeTypes.ts` and uses subpath imports to break circular dependencies
- Adds `scripts/check-circular-deps.mjs` with a baseline to prevent new cycles
- Preserves idfixes behavior: UUID validation, webpack IgnorePlugin, CardEditPanel editable fields

## Test plan
- [x] `node scripts/check-circular-deps.mjs` passes
- [ ] Server starts and catalog API loads cards from Firestore
- [ ] Export hellscube endpoint/scripts produce expected output
- [ ] Frontend card edit panel and changeset review still work
- [ ] Webpack build succeeds with `@google-cloud/*` ignored in browser bundle


Made with [Cursor](https://cursor.com)